### PR TITLE
Message api

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,46 @@
+$(document).on('turbolinks:load', function(){
+  function buildHTML(message){
+    var img = message.image.url ? message.image.url : "" ;
+    var html = `<div class="message"> 
+                  <div class="message__upper-info">
+                    <div class="message__upper-info--name">
+                      ${message.user_name}
+                    </div>
+                    <div class="message__upper-info--date-time">
+                      ${message.created_at}
+                    </div>
+                    </div>
+                    <div class="message__text">
+                      <p class="lower-message__content">
+                      ${message.content}
+                      </p>
+                      <img src = '${img}' class = 'lower-message__image ' >
+                  </div>
+                </div>`
+    return html;
+  }
+
+  $('#new_message').on('submit', function(e){
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr('action')
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+    .done(function(data){
+      var html = buildHTML(data);
+      $('.messages').append(html)
+      $('#new_message')[0].reset();
+      $('.main-body').animate({ scrollTop: $('.main-body')[0].scrollHeight});
+      $('.send-btn').prop('disabled', false);
+    })
+    .fail(function(){
+      alert('エラーが発生したためメッセージは送信できませんでした。');
+    })
+  })
+});

--- a/app/assets/stylesheets/_messages.scss
+++ b/app/assets/stylesheets/_messages.scss
@@ -93,11 +93,11 @@
 .main-body {
   height: calc(100vh - 190px);
   background-color: #fafafa;
+  overflow: scroll;
 }
 
 .messages {
   padding: 46px 40px 0 ;
-  overflow: scroll;
 }
 
 .message {
@@ -174,4 +174,8 @@
   margin-left: 15px;
   padding: 0 30px;
   cursor: pointer;
+}
+
+.lower-message__image {
+  width: 200px;
 }

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,10 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.html { redirect_to group_messages_path(@group), notice: 'メッセージが送信されました' }
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.content  @message.content
+json.user_name  @message.user.name
+json.created_at  @message.created_at.strftime("%Y/%m/%d %H:%M")
+json.image  @message.image

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,5 +18,7 @@ module ChatSpace
       g.test_framework false
     end
     config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
   end
 end
+


### PR DESCRIPTION
# What
メッセージ送信機能を非同期通信で行えるように設定
1.フォームが送信されたら、イベントが発火するようにする
2.イベントが発火したときにAjaxを使用して、messages#createが動くようにする
3.messages#createでメッセージを保存し、respond_toを使用してHTMLとJSONの場合で処理を分ける
4.jbuilderを使用して、作成したメッセージをJSON形式で返す
5.返ってきたJSONをdoneメソッドで受取り、HTMLを作成する
6.作成したHTMLをメッセージ画面の一番下に追加する
7.HTMLを追加した分、メッセージ画面を下にスクロールする
8.連続で送信ボタンを押せるようにする
9.非同期に失敗した場合の処理も準備する

# Why
非同期通信で行えるようにすることによって、ページの読み込み時間が短縮され、ページの読み込み遅延によるユーザーの離脱を最小限におさえることができる